### PR TITLE
Fix the PullApprove approve_regex to cover more cases

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,5 +1,5 @@
 approve_by_comment: true
-approve_regex: ^LGTM
+approve_regex: '^(Approved|lgtm|LGTM|:shipit:|:star:|:\+1:|:ship:)'
 reject_regex: ^Rejected
 reset_on_push: true
 reviewers:


### PR DESCRIPTION
'^(Approved|lgtm|LGTM|:shipit:|:star:|:\+1:|:ship:)'

Signed-off-by: Chris Aniszczyk <caniszczyk@gmail.com>